### PR TITLE
Fixes to work with Node-RED 0.20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Run the following command in your node-RED user directory (typically `~/.node-re
 
 ## Content
 
-ctr700_di:      node to handle digital inputs
-ctr700_do:      node to handle digital outputs
-ctr700_ai:      node to handle analog inputs
-ctr700_led:     node to handle run and error led of the module
-ctr700_switch:  node to handle run/stop switch of the module
+- *ctr700_di*:      node to handle digital inputs
+- *ctr700_do*:      node to handle digital outputs
+- *ctr700_ai*:      node to handle analog inputs
+- *ctr700_led*:     node to handle run and error led of the module
+- *ctr700_switch*:  node to handle run/stop switch of the module
 
 
 ## Node status

--- a/ctr700_ai.js
+++ b/ctr700_ai.js
@@ -25,6 +25,7 @@
   Revision History:
 
   2018/02/25 -rs:   V1.00 Initial version
+  2019/03/20 -ad:   V1.01 Fix handling for initial value
 
 ****************************************************************************/
 
@@ -45,7 +46,6 @@ module.exports = function(RED)
     //  Import external modules
     //=======================================================================
 
-    const RedRuntimeEvents = require("/usr/lib/node_modules/node-red/red/runtime/events");
     const ctr700drv = require('./ctr700drv.js');
 
 
@@ -105,8 +105,11 @@ module.exports = function(RED)
         // register handler for event type 'close'
         ThisNode.on ('close', Ctr700_AI_NodeHandler_OnClose);
 
-        // register one-time handler for event type 'nodes-started'
-        RedRuntimeEvents.once ('nodes-started', Ctr700_AI_NodeHandler_OnNodesStarted);
+        // register one-time handler for sending the initial value
+        ThisNode.m_injectImmediate = setImmediate(function()
+        {
+            Ctr700_AI_NodeHandler_OnNodesStarted();
+        });
 
         // run handler for event type 'open'
         Ctr700_AI_NodeHandler_OnOpen (NodeConfig_p);
@@ -281,6 +284,12 @@ module.exports = function(RED)
         {
 
             TraceMsg ('{Ctr700_AI_Node} closing...');
+
+            // clear immediate timeout
+            if (ThisNode.m_injectImmediate)
+            {
+                clearImmediate(ThisNode.m_injectImmediate);
+            }
 
             // clear interval timer for cyclic data processing
             if (ThisNode.m_objSampleTimerID != -1)

--- a/ctr700_do.js
+++ b/ctr700_do.js
@@ -25,6 +25,7 @@
   Revision History:
 
   2018/02/25 -rs:   V1.00 Initial version
+  2019/03/20 -ad:   V1.01 Fix handling for initial value
 
 ****************************************************************************/
 
@@ -45,7 +46,6 @@ module.exports = function(RED)
     //  Import external modules
     //=======================================================================
 
-    const RedRuntimeEvents = require("/usr/lib/node_modules/node-red/red/runtime/events");
     const ctr700drv = require('./ctr700drv.js');
 
 
@@ -92,8 +92,11 @@ module.exports = function(RED)
         // register handler for event type 'close'
         ThisNode.on ('close', Ctr700_DO_NodeHandler_OnClose);
 
-        // register one-time handler for event type 'nodes-started'
-        RedRuntimeEvents.once ('nodes-started', Ctr700_DO_NodeHandler_OnNodesStarted);
+        // register one-time handler for sending the initial value
+        ThisNode.m_injectImmediate = setImmediate(function()
+        {
+            Ctr700_DO_NodeHandler_OnNodesStarted();
+        });
 
         // run handler for event type 'open'
         Ctr700_DO_NodeHandler_OnOpen (NodeConfig_p);
@@ -200,6 +203,12 @@ module.exports = function(RED)
         {
 
             TraceMsg ('{Ctr700_DO_Node} closing...');
+
+            // clear immediate timeout
+            if (ThisNode.m_injectImmediate)
+            {
+                clearImmediate(ThisNode.m_injectImmediate);
+            }
 
             // set output to inactive
             TraceMsg ('{Ctr700_DO_Node} set output inactive: ' + ThisNode.m_iChannelNumber.toString());

--- a/ctr700_led.js
+++ b/ctr700_led.js
@@ -25,6 +25,7 @@
   Revision History:
 
   2018/02/25 -rs:   V1.00 Initial version
+  2019/03/20 -ad:   V1.01 Fix handling for initial value
 
 ****************************************************************************/
 
@@ -45,7 +46,6 @@ module.exports = function(RED)
     //  Import external modules
     //=======================================================================
 
-    const RedRuntimeEvents = require("/usr/lib/node_modules/node-red/red/runtime/events");
     const ctr700drv = require('./ctr700drv.js');
 
 
@@ -92,8 +92,11 @@ module.exports = function(RED)
         // register handler for event type 'close'
         ThisNode.on ('close', Ctr700_LED_NodeHandler_OnClose);
 
-        // register one-time handler for event type 'nodes-started'
-        RedRuntimeEvents.once ('nodes-started', Ctr700_LED_NodeHandler_OnNodesStarted);
+        // register one-time handler for sending the initial value
+        ThisNode.m_injectImmediate = setImmediate(function()
+        {
+            Ctr700_LED_NodeHandler_OnNodesStarted();
+        });
 
         // run handler for event type 'open'
         Ctr700_LED_NodeHandler_OnOpen (NodeConfig_p);
@@ -199,6 +202,12 @@ module.exports = function(RED)
         {
 
             TraceMsg ('{Ctr700_LED_Node} closing...');
+
+            // clear immediate timeout
+            if (ThisNode.m_injectImmediate)
+            {
+                clearImmediate(ThisNode.m_injectImmediate);
+            }
 
             // set output to inactive
             TraceMsg ('{Ctr700_LED_Node} set output inactive: ' + ThisNode.m_strLed);

--- a/ctr700_switch.js
+++ b/ctr700_switch.js
@@ -8,45 +8,17 @@
 
   -------------------------------------------------------------------------
 
-  License:
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions
-    are met:
+      http://www.apache.org/licenses/LICENSE-2.0
 
-    1. Redistributions of source code must retain the above copyright
-       notice, this list of conditions and the following disclaimer.
-
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
-
-    3. Neither the name of SYSTEC electronic GmbH nor the names of its
-       contributors may be used to endorse or promote products derived
-       from this software without prior written permission. For written
-       permission, please contact info@systec-electronic.com.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-
-    Severability Clause:
-
-        If a provision of this License is or becomes illegal, invalid or
-        unenforceable in any jurisdiction, that shall not affect:
-        1. the validity or enforceability in that jurisdiction of any other
-           provision of this License; or
-        2. the validity or enforceability in other jurisdictions of that or
-           any other provision of this License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 
   -------------------------------------------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ref-array": "1.2.0",
     "ref-struct": "1.1.0"
   },
-  "keywords": [ 
+  "keywords": [
     "sysworxx",
     "ctr700",
     "node-red"
@@ -30,4 +30,3 @@
     }
   }
 }
-


### PR DESCRIPTION
The following modules cannot be used anymore:
`const RedRuntimeEvents = require("/usr/lib/node_modules/node-red/red/runtime/events");`
The patches fixes errors caused by using this.